### PR TITLE
Почему-то на ruby 2.0 после require_relative вызов require честно пытает...

### DIFF
--- a/lib/axiomus_api.rb
+++ b/lib/axiomus_api.rb
@@ -25,9 +25,9 @@ module AxiomusApi
 
 end
 
-require_relative('axiomus_api/actions')
-require_relative('axiomus_api/errors')
-require_relative('axiomus_api/response_codes')
+require 'axiomus_api/actions'
+require 'axiomus_api/errors'
+require 'axiomus_api/response_codes'
 
 Dir.glob(File.join(File.dirname(__FILE__),'axiomus_api/**/*.rb')).each do |file|
   require_relative(file)


### PR DESCRIPTION
...ся подгрузить файл второй раз:

2.0.0-p247 :001 > require 'axiomus_api'
/home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api/errors.rb:2: warning: already initialized constant AxiomusApi::Errors::Error
/usr/home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api/errors.rb:2: warning: previous definition of Error was here
TypeError: superclass mismatch for class RequestError
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api/errors.rb:4:in `<module:Errors>'
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api/errors.rb:1:in`<top (required)>'
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api.rb:33:in `require_relative'
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api.rb:33:in`block in <top (required)>'
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api.rb:32:in `each'
    from /home/deploy/.rvm/gems/ruby-2.0.0-p247/gems/axiomus_api-0.5.1/lib/axiomus_api.rb:32:in`<top (required)>'
    from /home/deploy/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /home/deploy/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:135:in`rescue in require'
    from /home/deploy/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from (irb):1
    from /home/deploy/.rvm/rubies/ruby-2.0.0-p247/bin/irb:12:in`<main>'
